### PR TITLE
Added ability to pass in a raw chunk of CSS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Usage
     -i, --ignore <selector, ...>   Do not remove given selectors
     -C, --csspath <path>           Relative path where the CSS files are located
     -s, --stylesheets <file, ...>  Specify additional stylesheets to process
+    -r, --raw <string>             Pass in a raw string of CSS
     -t, --timeout <milliseconds>   Wait for JS evaluation
 
 
@@ -33,6 +34,7 @@ Usage
             compress: true,
             ignore: ['#added_at_runtime', /test\-[0-9]+/],
             csspath: "../public/css/",
+            raw: 'h1 { color: green }',
             stylesheets: ["lib/bootstrap/dist/css/bootstrap.css", "src/public/css/main.css"],
             timeout: 1000
         };
@@ -57,6 +59,7 @@ Usage
 - __ignore__ [Array]: provide a list of selectors that should not be removed by UnCSS. For example, styles added by user interaction with the page (hover, click), since those are not detectable by UnCSS yet. Both literal names and regex patterns are recognized.
 - __csspath__ [String]: Path where the CSS files are related to the html files. By default, UnCSS uses the path specified in the <link rel="stylesheet" href="path/to/file.css"\>
 - __stylesheets__ [Array]: Force the list of stylesheets to optimize using a path relative to the `Gruntfile.js`. Otherwise, it extracts the stylesheets from the html files.
+- __raw__ [String]: Give the task a raw string of CSS in addition to the existing stylesheet options; useful in scripting when your CSS hasn't yet been written to disk.
 - __timeout__ [Number]: Specify how long to wait for the JS to be loaded.
 
 ### grunt-uncss ###

--- a/bin/index.js
+++ b/bin/index.js
@@ -14,6 +14,7 @@
         .option('-i, --ignore <selector, ...>', 'Do not remove given selectors')
         .option('-C, --csspath <path>', 'Relative path where the CSS files are located')
         .option('-s, --stylesheets <file, ...>', 'Specify additional stylesheets to process')
+        .option('-r, --raw <string>', 'Pass in a raw string of CSS')
         .option('-t, --timeout <milliseconds>', 'Wait for JS evaluation')
         .parse(process.argv);
 

--- a/lib/uncss.js
+++ b/lib/uncss.js
@@ -35,34 +35,46 @@ function uncss(files, doms, options, callback) {
             return utility.extract_stylesheets(html);
         });
 
-        if (_.flatten(stylesheets).length === 0) {
-            /* Could not extract a css file */
-            callback('');
-            return;
-        }
-
-        /* Now we have:
-         *  files       = ['some_file.html', 'some_other_file.html']
-         *  stylesheets = [['relative_css_path.css', ...],
-         *                 ['maybe_a_duplicate.css', ...]]
-         * We need to - make the stylesheets' paths relative to the HTML files,
-         *            - flatten the array,
-         *            - remove duplicates
-         */
-        stylesheets = stylesheets.map(function (arr, i) {
-            return arr.map(function (el) {
-                var p = path.join(path.dirname(files[i]), options.csspath, el);
-                return p;
+        if ( ! _.flatten(stylesheets).length === 0) {
+            /* Only run this if we found links to stylesheets (there may be none...)
+             *  files       = ['some_file.html', 'some_other_file.html']
+             *  stylesheets = [['relative_css_path.css', ...],
+             *                 ['maybe_a_duplicate.css', ...]]
+             * We need to - make the stylesheets' paths relative to the HTML files,
+             *            - flatten the array,
+             *            - remove duplicates
+             */
+            stylesheets = stylesheets.map(function (arr, i) {
+                return arr.map(function (el) {
+                    var p = path.join(path.dirname(files[i]), options.csspath, el);
+                    return p;
+                });
             });
-        });
-        stylesheets = _.flatten(stylesheets);
-        stylesheets = stylesheets.filter(function (e, i, arr) {
-            return arr.lastIndexOf(e) === i;
-        });
+            stylesheets = _.flatten(stylesheets);
+            stylesheets = stylesheets.filter(function (e, i, arr) {
+                return arr.lastIndexOf(e) === i;
+            });
+            /* Read the stylesheets and parse the CSS */
+            stylesheets = utility.mapReadFiles(stylesheets);
+        } else {
+            /* Reset the array if we didn't find any link tags */
+            stylesheets = [];
+        }
     }
-
-    /* Read the stylesheets and parse the CSS */
-    stylesheets  = utility.mapReadFiles(stylesheets);
+    /* If we specified a raw string of CSS, add it to the stylesheets array */
+    if (options.raw && typeof options.raw === 'string') {
+        stylesheets.push(options.raw);
+    }
+    /* At this point, there isn't any point in running the rest of the task if:
+     * - We didn't specify any stylesheet links in the options object
+     * - We couldn't find any stylesheet links in the HTML itself
+     * - We weren't passed a string of raw CSS in addition to, or to replace either of the above
+    */
+    if (_.flatten(stylesheets).length === 0) {
+        callback('');
+        return;
+    }
+    /* OK, so we have some CSS to work with! */
     parsed_css = css.parse(stylesheets.join('\n'));
 
     /* Remove unused rules and return the stylesheets to strings */


### PR DESCRIPTION
I've written a small patch to allow a user to pass in a string of raw CSS. Useful if the CSS that's being analysed is coming from another source that's not on disk; this is in addition to the `stylesheets` option, but can be used exclusively as well. E.g. a sample configuration could look like:

```
var files   = ['my', 'array', 'of', 'HTML', 'files'],
    options = {
        ignore: ['#added_at_runtime'],
        raw: 'h1 { color: green }'
    };

uncss(files, options, function (output) {
    console.log(output);
});
```

Would have liked to add in unit testing for this feature but it doesn't seem like you have an automated test suite? Mocha is pretty nice. It would make adding new features like this a lot easier. Anyway, let me know what you think. :-)
