### PR TITLE
Fixed crash when ignore wasn't specified.

### DIFF
--- a/lib/uncss.js
+++ b/lib/uncss.js
@@ -18,6 +18,7 @@ var async   = require('async'),
  */
 function uncss(files, doms, options, callback) {
     var stylesheets,
+        ignore_css,
         parsed_css,
         used_css;
 
@@ -65,8 +66,10 @@ function uncss(files, doms, options, callback) {
     stylesheets  = utility.mapReadFiles(stylesheets);
     parsed_css = css.parse(stylesheets.join('\n'));
 
+    /* Do we have any CSS to ignore? */ 
+    ignore_css = options.ignore || '';
     /* Remove unused rules and return the stylesheets to strings */
-    used_css = utility.filterUnusedRules(doms, parsed_css.stylesheet, options.ignore);
+    used_css = utility.filterUnusedRules(doms, parsed_css.stylesheet, ignore_css);
     used_css = css.stringify(used_css);
     /*  Minify? */
     if (options.compress) {


### PR DESCRIPTION
Small bugfix; I didn't specify `ignore` when testing my last patch and it was throwing this error:

```
~/js/uncss/lib/lib.js:100
        if (ignore.indexOf(selector) !== -1) {
                   ^
TypeError: Cannot call method 'indexOf' of undefined
    at ~/js/uncss/lib/lib.js:100:20
    at Array.filter (native)
    at filterUnusedSelectors (~/js/uncss/lib/lib.js:94:22)
    at ~/js/uncss/lib/lib.js:160:17
    at Array.forEach (native)
    at Object.filterUnusedRules (~/js/uncss/lib/lib.js:157:11)
    at uncss (~/js/uncss/lib/uncss.js:81:24)
    at ~/js/uncss/lib/uncss.js:132:13
    at ~/js/uncss/node_modules/async/lib/async.js:229:13
    at ~/js/uncss/node_modules/async/lib/async.js:110:21
```

This makes it so you can ignore the `ignore` option. :-)
