### PR TITLE
Beginnings of a test suite.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha tests/*.js --reporter min"
   },
   "bin": {
     "uncss": "bin/index.js"
@@ -34,5 +34,9 @@
     "underscore": "~1.5.2",
     "async": "~0.2.9",
     "phantomjs": "~1.9.2-5"
+  },
+  "devDependencies": {
+    "mocha": "~1.15.1",
+    "chai": "~1.8.1"
   }
 }

--- a/tests/fixtures/adjacent.css
+++ b/tests/fixtures/adjacent.css
@@ -1,0 +1,7 @@
+span + span {
+    text-decoration: underline;
+}
+
+#battleground + div {
+    background: white;
+}

--- a/tests/fixtures/child.css
+++ b/tests/fixtures/child.css
@@ -1,0 +1,7 @@
+h1 > span {
+    color: crimson;
+}
+
+div > span {
+    color: #000;
+}

--- a/tests/fixtures/classes.css
+++ b/tests/fixtures/classes.css
@@ -1,0 +1,11 @@
+.red {
+    color: red;
+}
+
+.blue {
+    color: blue;
+}
+
+.green {
+    color: green;
+}

--- a/tests/fixtures/elements.css
+++ b/tests/fixtures/elements.css
@@ -1,0 +1,19 @@
+body {
+    font-size: 100%;
+}
+
+h1 {
+    font-size: 2rem;
+}
+
+h2 {
+    font-size: 1.5rem;
+}
+
+p {
+    font-size: 1em;
+}
+
+span {
+    display: block;
+}

--- a/tests/fixtures/generalsibling.css
+++ b/tests/fixtures/generalsibling.css
@@ -1,0 +1,7 @@
+.red ~ span {
+    color: blue;
+}
+
+.blue ~ span {
+    color: green;
+}

--- a/tests/fixtures/ids.css
+++ b/tests/fixtures/ids.css
@@ -1,0 +1,8 @@
+#battleground {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, .15);
+}
+
+#playground,
+#fairground {
+    color: white;
+}

--- a/tests/fixtures/mediaqueries.css
+++ b/tests/fixtures/mediaqueries.css
@@ -1,0 +1,6 @@
+@media screen and (min-width:320px) {
+    body,
+    a {
+        color: blue;
+    }
+}

--- a/tests/fixtures/not.css
+++ b/tests/fixtures/not.css
@@ -1,0 +1,4 @@
+div:not(#bat):not(#man),
+div:not(#battleground) {
+    display: inline-block;
+}

--- a/tests/fixtures/nthchild.css
+++ b/tests/fixtures/nthchild.css
@@ -1,0 +1,11 @@
+span:nth-child(odd) {
+    border-bottom: 1px solid red;
+}
+
+span:nth-child(2) {
+    border-bottom: 1px solid blue;
+}
+
+span:nth-child(3) {
+    border-bottom: 1px solid blue;
+}

--- a/tests/fixtures/nthoftype.css
+++ b/tests/fixtures/nthoftype.css
@@ -1,0 +1,7 @@
+span:nth-of-type(2) {
+    border-bottom: 1px solid blue;
+}
+
+span:nth-of-type(4) {
+    border-bottom: 1px solid white;
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Red vs. Blue</title>
+    </head>
+    <body>
+        <div id="battleground">
+            <h1><span class="red">Red</span> vs. <span class="blue">Blue</span></h1>
+        </div>
+    </body>
+</html>

--- a/tests/selectors.js
+++ b/tests/selectors.js
@@ -1,0 +1,57 @@
+/* jshint node: true */
+/* global describe, it, before, beforeEach, after, afterEach */
+'use strict';
+
+var expect    = require('chai').expect,
+    fs        = require('fs'),
+    path      = require('path'),
+    uncss     = require('./../lib/uncss.js');
+
+/* Read file sync sugar. */
+var rfs = function(file) {
+    return fs.readFileSync(path.join(__dirname, file), 'utf-8').toString();
+};
+
+var rawcss = false;
+var tests = fs.readdirSync(path.join(__dirname, 'fixtures/'));
+var input = '';
+
+/* Only read through CSS files */
+tests.forEach(function(test, i) {
+    if (test.indexOf('.css') > -1) {
+        input += rfs('fixtures/' + test);
+    } else {
+        tests.splice(i, 1);
+    }
+});
+
+uncss(rfs('index.html'), { compress: true, raw: input }, function(output) {
+    rawcss = output;
+});
+
+describe('uncss', function() {
+    /* Need a bit more time for PhantomJS */
+    this.timeout(5000);
+    /* Wait until uncss finished doing its thing before running our tests */
+    var check = function(done) {
+        if (rawcss) {
+            done();
+        } else {
+            setTimeout(function() {
+                check(done);
+            }, 500);
+        }
+    };
+
+    before(function(done) {
+        check(done);
+    });
+    /* We're testing that the CSS is stripped out from the result, not that the result contains
+       the CSS in the unused folder. */
+    tests.forEach(function(test) {
+        it('should handle ' + test.split('.')[0], function() {
+            expect(rawcss).to.not.include.string(rfs('unused/' + test));
+        }); 
+    });
+
+});

--- a/tests/unused/adjacent.css
+++ b/tests/unused/adjacent.css
@@ -1,0 +1,1 @@
+#battleground+div{background:#fff}

--- a/tests/unused/child.css
+++ b/tests/unused/child.css
@@ -1,0 +1,1 @@
+div>span{color:#000}

--- a/tests/unused/classes.css
+++ b/tests/unused/classes.css
@@ -1,0 +1,1 @@
+.green{color:green}

--- a/tests/unused/elements.css
+++ b/tests/unused/elements.css
@@ -1,0 +1,1 @@
+h2{font-size:1.5rem}p{font-size:1em}

--- a/tests/unused/generalsibling.css
+++ b/tests/unused/generalsibling.css
@@ -1,0 +1,1 @@
+.blue~span{color:green}

--- a/tests/unused/ids.css
+++ b/tests/unused/ids.css
@@ -1,0 +1,1 @@
+#playground,#fairground{color:#fff}

--- a/tests/unused/mediaqueries.css
+++ b/tests/unused/mediaqueries.css
@@ -1,0 +1,1 @@
+@media screen and (min-width:320px){body,a{color:#00f}}

--- a/tests/unused/not.css
+++ b/tests/unused/not.css
@@ -1,0 +1,1 @@
+div:not(#battleground){display:inline-block}

--- a/tests/unused/nthchild.css
+++ b/tests/unused/nthchild.css
@@ -1,0 +1,1 @@
+span:nth-child(3){border-bottom:1px solid #00f}

--- a/tests/unused/nthoftype.css
+++ b/tests/unused/nthoftype.css
@@ -1,0 +1,1 @@
+span:nth-of-type(2){border-bottom:1px solid #fff}


### PR DESCRIPTION
This fixes #13; a beginning of a test suite (currently 10 tests) run via Mocha. The tests work by parsing the whole `fixtures` directory into a raw string of CSS and passing that to UnCSS. Then, the tests check in the `unused` directory to make sure what is in there is _not_ in the CSS output. Think this is quite a nice way to test the module going forward.

The only problem with this is each test doesn't have a 'clean slate' when it runs, but if it did the test suite would take up more like 16-20 seconds (as it stands, and more when other tests are added). I'd like to know what you think of this approach.
