### PR TITLE
Fix for parameters in local files

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -87,6 +87,9 @@ function parsePaths(source, stylesheets, options) {
              * Should probably report an error if we find an absolute path and
              *   have no htmlroot specified.
              */
+
+            /* Fix the case when there is a query string or hash */
+            sheet = sheet.split('?')[0].split('#')[0];
             if (sheet[0] === '/' && options.htmlroot) {
                 _path = path.join(options.htmlroot, sheet);
             } else {

--- a/tests/selectors/index.html
+++ b/tests/selectors/index.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/colors/1.0/colors.min.css">
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400">
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.0.3/css/font-awesome.min.css">
-        <link rel="stylesheet" href="fixtures/adjacent.css">
+        <link rel="stylesheet" href="fixtures/adjacent.css?v=123">
         <link rel="stylesheet" href="fixtures/child.css">
         <link rel="stylesheet" href="fixtures/classes.css">
         <link rel="stylesheet" href="fixtures/complex.css">


### PR DESCRIPTION
There was an issue when local file has query string (likely) or hash parameters (not so likely).
Since having query string is quite possible (especially when using uncss after build, for invalidating the browser's cache), I provide a fix.

Example:

```
<!doctype html>
  <html>
    <head>
      <link rel="stylesheet" href="fixtures/adjacent.css?v=123">
    </head>
  <body>
  </body>
</html>
```
