### PR TITLE
Remove deprecated gulp task

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ UnCSS can also be used in conjunction with other javascript build systems, such 
 Thanks to @addyosmani for creating:
 
 - [grunt-uncss](https://github.com/addyosmani/grunt-uncss)
-- [gulp-uncss-task](https://github.com/addyosmani/gulp-uncss-task)
 
 and to @ben-eb for creating:
 


### PR DESCRIPTION
This is a deprecated task and it is completely outdated.
