### PR TITLE
Update dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "async": "~0.9.0",
     "commander": "~2.3.0",
     "css": "~2.1.0",
-    "phantomjs": "~1.9.7-15",
+    "phantomjs": "~1.8.2-3",
     "node-phantom-simple": "~1.2.0",
     "request": "~2.40.0",
-    "underscore": "~1.6.0"
+    "underscore": "~1.7.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",
@@ -51,7 +51,7 @@
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-mocha-cov": "~0.3.0",
-    "time-grunt": "~0.4.0"
+    "time-grunt": "~1.0.0"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
PS. I'm getting a test failure on Windows regardless of this patch

```
C:\Users\xmr\Desktop\uncss>node -v && npm -v
v0.10.31
1.4.23

C:\Users\xmr\Desktop\uncss>grunt test --force
Running "jshint:all" (jshint) task
>> 13 files lint free.

Running "mochacov:unit" (mochacov) task


  Options
    √ options.stylesheets should override <link> tags
    √ options.ignoreSheets should be respected
    √ options.raw should be added to the processed CSS
    √ options.ignore should be added to the output and accept a regex
    √ options.htmlroot should be respected
    √ options.urls should be processed
    √ options.media should default to screen, all
    1) options.media should be configurable
AssertionError: expected '/*** uncss> filename: tests\\selectors\\fixtures\\adja
cent.css ***/\n\nspan + span {\n  text-decoration: underline;\n}\n\n/*** uncss>
filename: tests\\selectors\\fixtures\\child.css ***/\n\nh1 > span {\n  color: cr
imson;\n}\n\n/*** uncss> filename: tests\\selectors\\fixtures\\complex.css ***/\
n\n[data-section=\'\'] > section > [data-section-title] h4 {\n  color: cyan;\n}\
n' to include '.red {\n  color: red;\n}\n\n.blue {\n  color: blue;\n}\n'
    at C:\Users\xmr\Desktop\uncss\tests\coverage.js:104:31
    at C:\Users\xmr\Desktop\uncss\lib\uncss.js:259:20
    at C:\Users\xmr\Desktop\uncss\lib\uncss.js:205:16
    at C:\Users\xmr\Desktop\uncss\lib\lib.js:348:20
    at C:\Users\xmr\Desktop\uncss\node_modules\async\lib\async.js:670:13
    at done (C:\Users\xmr\Desktop\uncss\node_modules\async\lib\async.js:135:19)
    at C:\Users\xmr\Desktop\uncss\node_modules\async\lib\async.js:32:16
    at C:\Users\xmr\Desktop\uncss\node_modules\async\lib\async.js:667:17
    at C:\Users\xmr\Desktop\uncss\lib\phantom.js:187:20
    at C:\Users\xmr\Desktop\uncss\node_modules\node-phantom-simple\node-phantom-simple.js:40:26
    at IncomingMessage.<anonymous> (C:\Users\xmr\Desktop\uncss\node_modules\node-phantom-simple\node-phantom-simple.js:455:17)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:943:16
    at process._tickCallback (node.js:419:13)
Warning:  Used --force, continuing.

Done, but with warnings.


Execution Time (2014-08-30 15:42:48 UTC)
jshint:all     219ms  ██ 3%
mochacov:unit   6.3s  ██████████████████████████████████████████████ 97%
Total 6.5s

```
