### PR TITLE
Add ignore string regex conversion.

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -157,7 +157,7 @@ function filterUnusedSelectors(pages, selectors, ignore, used_selectors) {
         }
         for (i = 0; i < ignore.length; ++i) {
             /* If ignore is a string and looks like a regex - typically from the command line */
-            if (typeof ignore[i] === "string" && /\/[^\/]+\/[gimy]*/.test(ignore[i])) {
+            if (typeof ignore[i] === 'string' && /\/[^\/]+\/[gimy]*/.test(ignore[i])) {
                 var flags = ignore[i].replace(/.*\/([gimy]*)$/, '$1');
                 var pattern = ignore[i].replace(new RegExp('^/(.*?)/'+flags+'$'), '$1');
                 ignore[i] = new RegExp(pattern, flags);


### PR DESCRIPTION
When using the command line, I was unable to specify a regex to use as an ignore. This addition checks if an ignore is a regex string and converts it before matching selectors.
