### PR TITLE
Allow any SSL (TLS) protocol in PhantomJS

### DIFF
--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -46,7 +46,10 @@ function init(numThreads, instance_array, callback) {
                 return done(null);
             }, {
                 phantomPath: phantomPath,
-                parameters: {'ignore-ssl-errors': 'yes'}
+                parameters: {
+                    'ignore-ssl-errors': 'yes',
+                    'ssl-protocol':'any'
+                }
             });
         },
         callback


### PR DESCRIPTION
By default PhantomJS try to establish the secure connection only with SSL3. This change allow to use other protocols like TLSv1 (or SSLv2)

This fix many issues with the actual process of shut down SSLv3 protocol.
