### PR TITLE
let "stylesheets" option be able to accept files from unrelative paths

### DIFF
--- a/lib/uncss.js
+++ b/lib/uncss.js
@@ -116,6 +116,9 @@ function getCSS(files, pages, stylesheets, options, callback) {
         stylesheets =
             _.chain(stylesheets)
             .map(function (sheets, i) {
+            	if (/^https?/.test(files[i])) {
+                  return sheets;
+                }
                 return lib.parsePaths(files[i], sheets, options);
             })
             .flatten()


### PR DESCRIPTION
Let 

```
stylesheets  : ['src/main/webapp/css/minified/test.css','src/main/webapp/css/minified/test2.css','src/main/webapp/css/minified/test3.css'],
```

become possible, since **readStylesheets** method also check whether files from absolute url:

```
function readStylesheets(files, callback) {
  return async.map(files, function(filename, done) {
    if(filename.match(/^http/)) {
      request(
        filename,
        { headers: {'User-Agent': 'UnCSS'} },
        function(err, res, body) {
          if(err) {
            return done(err);
          }
          return done(null, body);
        }
      );
    } else {
      if(fs.existsSync(filename)) {
        return fs.readFile(filename, 'utf8', done);
      }
      return done(new Error('UnCSS: could not open ' + path.join(process.cwd(), filename)));
    }
  }, callback);
}
```
