### PR TITLE
Simplify main exported function.

### DIFF
--- a/lib/uncss.js
+++ b/lib/uncss.js
@@ -229,7 +229,7 @@ function uncss(pages, stylesheets, options, callback) {
  * @param  {Function} callback(Error, String, Object)
  */
 function init(files, options, callback) {
-    var numThreads = (typeof files === 'string') ? 1 : files.length;
+    var numThreads = typeof files === 'string' ? 1 : files.length;
 
     if (typeof options === 'function') {
         /* There were no options, this argument is actually the callback */


### PR DESCRIPTION
Simplifies the variable argument checking and uses `object-assign` to assign defaults in a cleaner fashion. :smiley:
