### PR TITLE
Replace backslashes with forward slashes in banner.

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -95,7 +95,7 @@ function readStylesheets(files, callback) {
       for(var i = 0; i < files.length; i++) {
         // We append a small banner to keep track of which file we are currently processing
         // super helpful for debugging
-        var banner = '/*** uncss> filename: ' + files[i] + ' ***/\n';
+        var banner = '/*** uncss> filename: ' + files[i].replace(/\\/g, '/') + ' ***/\n';
         res[i] = banner + res[i];
       }
 


### PR DESCRIPTION
Without this, we ended up with different filename based on the platform.
On Windows, I'm getting for example:

``` diff
-/*** uncss> filename: tests/selectors/fixtures/adjacent.css ***/
+/*** uncss> filename: tests\selectors\fixtures\adjacent.css ***/
```

which marks some tests as modified.
