### PR TITLE
Phantom local files

### DIFF
--- a/src/phantom.js
+++ b/src/phantom.js
@@ -54,6 +54,7 @@ function ResourceHandler(htmlroot, isWindows, resolve) {
             url = originalUrl.split('?')[0].split('#')[0];
 
         if (url.substr(-3) === '.js' && url.substr(0, 7) === 'file://') {
+            console.log('Before: ' + url);
             /* Try and match protocol-less URLs and absolute ones.
              * Relative URLs will still not load.
              */
@@ -71,6 +72,7 @@ function ResourceHandler(htmlroot, isWindows, resolve) {
                 /* Protocol-less URL */
                 url = 'http://' + originalUrl.substr(7);
             }
+            console.log('After: ' + url);
             networkRequest.changeUrl(url);
         } else if (ignoreRequests.test(url)) {
             networkRequest.abort();

--- a/tests/phantomjs.js
+++ b/tests/phantomjs.js
@@ -16,6 +16,15 @@ describe('PhantomJS', function () {
         });
     });
 
+    it('should fetch local scripts', function (done) {
+        uncss(['tests/phantomjs/local_script.html'], {}, function (err, output) {
+            expect(err).to.equal(null);
+            expect(output).to.include('.append_absolute');
+            expect(output).to.include('.append_relative');
+            done();
+        });
+    });
+
     it('Should exit only when JS evaluation has finished', function (done) {
         this.timeout(25000);
         uncss(['tests/phantomjs/long_wait.html'], function (err, output) {

--- a/tests/phantomjs/js/append_absolute.js
+++ b/tests/phantomjs/js/append_absolute.js
@@ -1,0 +1,4 @@
+/* Append an element */
+var div = document.createElement('div');
+div.className = 'append_absolute';
+document.body.appendChild(div);

--- a/tests/phantomjs/js/append_relative.js
+++ b/tests/phantomjs/js/append_relative.js
@@ -1,0 +1,4 @@
+/* Append an element */
+var div = document.createElement('div');
+div.className = 'append_relative';
+document.body.appendChild(div);

--- a/tests/phantomjs/local_script.html
+++ b/tests/phantomjs/local_script.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>PhantomJS basic test</title>
+        <link rel="stylesheet" href="/phantomjs.css">
+    </head>
+    <body>
+        <script src="/js/append_relative.js"></script>
+        <script src="js/append_absolute.js"></script>
+    </body>
+</html>

--- a/tests/phantomjs/phantomjs.css
+++ b/tests/phantomjs/phantomjs.css
@@ -9,3 +9,11 @@
 .timeout {
   margin: 0;
 }
+
+.append_relative {
+    margin: 0;
+}
+
+.append_absolute {
+    margin: 0;
+}


### PR DESCRIPTION
@XhmikosR I think there is little we can do about this issue.
if you run `bin/uncss tests/phantomjs/local_script.html --htmlroot="tests/phantomjs"` you can see the problem is that both absolute-sourced scripts and relative ones have the same prefix, therefore it's impossible to differentiate between the two :/
