### PR TITLE
Make uncss:ignore survive CSS minifiers

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -202,7 +202,7 @@ function filterUnusedRules(pages, stylesheet, ignore, usedSelectors) {
     rules.forEach(function (rule, idx) {
         if (rule.type === 'comment') {
             // ignore next rule while using comment `/* uncss:ignore */`
-            if (/^\s?uncss:ignore\s?$/.test(rule.comment)) {
+            if (/^!?\s?uncss:ignore\s?$/.test(rule.comment)) {
                 nextRule = rules[idx + 1];
                 if (nextRule && nextRule.type === 'rule') {
                     ignore = ignore.concat(nextRule.selectors);


### PR DESCRIPTION
Regex has been updated to allow for an optional, leading `!` which will prevent it from being stripped by CSS minifiers/tools such as grunt-contrib-concat and grunt-cssmin. This will increase the flexibility of using grunt-uncss within various points of the task order.