### PR TITLE
Overhand files and option-Object, not files and timeout

### DIFF
--- a/src/uncss.js
+++ b/src/uncss.js
@@ -20,7 +20,7 @@ var promise = require('bluebird'),
 function getHTML(files, options) {
 
     if (_.isString(files)) {
-        return phantom.fromRaw(files, options.timeout).then(function (pages) {
+        return phantom.fromRaw(files, options).then(function (pages) {
             return [files, options, [pages]];
         });
     }


### PR DESCRIPTION
Dropped timeout here, because phantom.fromRaw expects files and option-Object, not files and timeout. fromRaw calls resolveWithPage after promise is solved and in there option.timeout is used, not only option, which would contain the timeout. 

Use this Repo to reproduce the bug: https://github.com/marcelwagner/uncss-bug-example

**Start to use the repo by, cloning it to local disk.
Install npm-dependencies.
Run gulp css.**

As you can see, the task takes under 20 seconds. But I configured in the gulpfile.js that the phantomjs-instance should wait for 20 seconds.

```javascript
...
line 10:         timeout: 20000
...
```

If you use my branch: *gulp_timeout_patch* for it, phantomjs will wait 20 secounds before it will get back the html. This you can see by the time the task runs and if you debug the task.

So now this works with gulp-plugin gulp-uncss (https://www.npmjs.com/package/gulp-uncss) and setting timeout-option. I think it would fix some other issues without gulp and/or grunt.