### PR TITLE
Add option ignoreModifiers, to ignore classes or other modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,17 @@ var uncss = require('uncss');
 
 var files   = ['my', 'array', 'of', 'HTML', 'files', 'or', 'http://urls.com'],
     options = {
-        ignore       : ['#added_at_runtime', /test\-[0-9]+/],
-        media        : ['(min-width: 700px) handheld and (orientation: landscape)'],
-        csspath      : '../public/css/',
-        raw          : 'h1 { color: green }',
-        stylesheets  : ['lib/bootstrap/dist/css/bootstrap.css', 'src/public/css/main.css'],
-        ignoreSheets : [/fonts.googleapis/],
-        timeout      : 1000,
-        htmlroot     : 'public',
-        report       : false,
-        uncssrc      : '.uncssrc'
+        ignore          : ['#element_added_at_runtime', /test\-[0-9]+/],
+        ignoreModifiers : ['.class_added_at_runtime', '.visible', '[disabled]'],
+        media           : ['(min-width: 700px) handheld and (orientation: landscape)'],
+        csspath         : '../public/css/',
+        raw             : 'h1 { color: green }',
+        stylesheets     : ['lib/bootstrap/dist/css/bootstrap.css', 'src/public/css/main.css'],
+        ignoreSheets    : [/fonts.googleapis/],
+        timeout         : 1000,
+        htmlroot        : 'public',
+        report          : false,
+        uncssrc         : '.uncssrc'
     };
 
 uncss(files, options, function (error, output) {
@@ -106,6 +107,8 @@ Options:
   }
   ```
 
+- **ignoreModifiers** (Array): Ignore a list of classes or other modifiers. Unlike **ignore**, this will only ignore a selector if the rest of the selector *does* match.
+
 - **media** (Array): By default UnCSS processes only stylesheets with media query "_all_", "_screen_", and those without one. Specify here which others to include.
 
 - **csspath** (String): Path where the CSS files are related to the HTML files. By default, UnCSS uses the path specified in the `<link rel="stylesheet" href="path/to/file.css"/>`.
@@ -122,7 +125,7 @@ Options:
 
 - **report** (Boolean): Return the report object in callback.
 
-- **uncssrc** (String): Load all options from a JSON file. Regular expressions for the `ignore` and `ignoreSheets` options should be wrapped in quotation marks.
+- **uncssrc** (String): Load all options from a JSON file. Regular expressions for the `ignore`, `ignoreModifiers` and `ignoreSheets` options should be wrapped in quotation marks.
 
   Example uncssrc file:
 

--- a/bin/uncss
+++ b/bin/uncss
@@ -6,6 +6,7 @@
     process.title = 'uncss';
 
     var uncss = require('../src/uncss.js'),
+        utility = require('../src/utility.js'),
         data = require('../package.json'),
         program = require('commander');
 
@@ -20,6 +21,7 @@
         .version(data.version)
         .usage('[options] <file or URL, ...>\n\t e.g. uncss http://getbootstrap.com/examples/jumbotron/ > stylesheet.css')
         .option('-i, --ignore <selector, ...>', 'Do not remove given selectors', listArg)
+        .option('-I, --ignoreModifiers <selector, ...>', 'Do not remove given selector modifiers', listArg)
         .option('-m, --media <media_query, ...>', 'Process additional media queries', listArg)
         .option('-C, --csspath <path>', 'Relative path where the CSS files are located')
         .option('-s, --stylesheets <file, ...>', 'Specify additional stylesheets to process', listArg)
@@ -32,6 +34,7 @@
 
     options = {
         ignore: program.ignore,
+        ignoreModifiers: program.ignoreModifiers,
         ignoreSheets: program.ignoreSheets,
         media: program.media,
         csspath: program.csspath,
@@ -60,16 +63,9 @@
             });
         });
     } else {
-        if (options.ignore) {
-            options.ignore = options.ignore.map(function (ign) {
-                /* Create RegExes */
-                if (ign[0] === '/') {
-                    /* Remove starting and trailing '/' */
-                    return new RegExp(ign.slice(1, -1));
-                }
-                return ign;
-            });
-        }
+        options.ignore = options.ignore ? options.ignore.map(utility.strToRegExp) : undefined;
+        options.ignoreModifiers = options.ignoreModifiers ? options.ignoreModifiers.map(utility.strToRegExp) : undefined;
+        options.ignoreSheets = options.ignoreSheets ? options.ignoreSheets.map(utility.strToRegExp) : undefined;
 
         /* If used from the command line, concatenate the output */
         uncss(program.args, options, function (err, css) {

--- a/src/lib.js
+++ b/src/lib.js
@@ -36,13 +36,46 @@ var dePseudify = (function () {
 }());
 
 /**
- * Private function used in filterUnusedRules.
- * @param  {Array} selectors      CSS selectors created by the CSS parser
- * @param  {Array} ignore         List of selectors to be ignored
- * @param  {Array} usedSelectors  List of Selectors found in the PhantomJS pages
- * @return {Array}                The selectors matched in the DOMs
+ * Remove modifier, such as ".visible" or "[disabled]".
  */
-function filterUnusedSelectors(selectors, ignore, usedSelectors) {
+function removeIgnoredModifier(match, i, selector) {
+    return !selector[i - 1] || /[\s>+(,]/.test(selector[i - 1]) ? '*' : '';
+}
+
+/**
+ * Remove modifiers, such as ".visible" or "[disabled]".
+ * @param  {Array} ignoreModifiers  List of selector modifiers to be ignored
+ * @return {Function}               Function to remove the modifiers
+ */
+function removeIgnoredModifiers(ignoreModifiers) {
+    if (!ignoreModifiers) {
+        return function (selector) {
+            return selector;
+        };
+    }
+    return function (selector) {
+        ignoreModifiers.forEach(function (ignoreModifier) {
+            while (
+                typeof ignoreModifier === 'string' ?
+                    selector.indexOf(ignoreModifier) !== -1 :
+                    ignoreModifier.test(selector)
+            ) {
+                selector = selector.replace(ignoreModifier, removeIgnoredModifier);
+            }
+        });
+        return selector;
+    };
+}
+
+/**
+ * Private function used in filterUnusedRules.
+ * @param  {Array} selectors        CSS selectors created by the CSS parser
+ * @param  {Array} ignore           List of selectors to be ignored
+ * @param  {Array} ignoreModifiers  List of selector modifiers to be ignored
+ * @param  {Array} usedSelectors    List of Selectors found in the PhantomJS pages
+ * @return {Array}                  The selectors matched in the DOMs
+ */
+function filterUnusedSelectors(selectors, ignore, ignoreModifiers, usedSelectors) {
     /* There are some selectors not supported for matching, like
      *   :before, :after
      * They should be removed only if the parent is not found.
@@ -50,8 +83,10 @@ function filterUnusedSelectors(selectors, ignore, usedSelectors) {
      *          is no '.clearfix'
      */
     var i = 0;
+    var removeIgnoredModifiersFunction = removeIgnoredModifiers(ignoreModifiers);
     return selectors.filter(function (selector) {
         selector = dePseudify(selector);
+        selector = removeIgnoredModifiersFunction(selector);
         /* TODO: process @-rules */
         if (selector[0] === '@') {
             return true;
@@ -135,17 +170,18 @@ function filterEmptyRules(rules) {
 
 /**
  * Find which selectors are used in {page}
- * @param  {Array}    page          List of PhantomJS pages
- * @param  {Object}   stylesheet    The output of css.parse().stylesheet
- * @param  {Boolean}  isRec         Used internally
+ * @param  {Array}    page             List of PhantomJS pages
+ * @param  {Object}   stylesheet       The output of css.parse().stylesheet
+ * @param  {Array}    ignoreModifiers  List of selector modifiers to be ignored
+ * @param  {Boolean}  isRec            Used internally
  * @return {promise}
  */
-function getUsedSelectors(page, stylesheet, isRec) {
+function getUsedSelectors(page, stylesheet, ignoreModifiers, isRec) {
     return promise.map(stylesheet.rules, function (rule) {
         if (rule.type === 'rule') {
             return rule.selectors;
         } else if (rule.type === 'media') {
-            return getUsedSelectors(page, rule, true);
+            return getUsedSelectors(page, rule, ignoreModifiers, true);
         }
         return [];
     }).then(function (selectors) {
@@ -153,7 +189,7 @@ function getUsedSelectors(page, stylesheet, isRec) {
         if (isRec) {
             return selectors;
         }
-        return phantom.findAll(page, selectors.map(dePseudify));
+        return phantom.findAll(page, selectors.map(dePseudify).map(removeIgnoredModifiers(ignoreModifiers)));
     });
 }
 
@@ -180,13 +216,14 @@ function getAllSelectors(stylesheet) {
 
 /**
  * Remove css rules not used in the dom
- * @param  {Array}  pages           List of PhantomJS pages
- * @param  {Object} stylesheet      The output of css.parse().stylesheet
- * @param  {Array}  ignore          List of selectors to be ignored
- * @param  {Array}  usedSelectors   List of selectors that are found in {pages}
- * @return {Object}                 A css_parse-compatible stylesheet
+ * @param  {Array}  pages            List of PhantomJS pages
+ * @param  {Object} stylesheet       The output of css.parse().stylesheet
+ * @param  {Array}  ignore           List of selectors to be ignored
+ * @param  {Array}  ignoreModifiers  List of selector modifiers to be ignored
+ * @param  {Array}  usedSelectors    List of selectors that are found in {pages}
+ * @return {Object}                  A css_parse-compatible stylesheet
  */
-function filterUnusedRules(pages, stylesheet, ignore, usedSelectors) {
+function filterUnusedRules(pages, stylesheet, ignore, ignoreModifiers, usedSelectors) {
     var rules = stylesheet.rules,
         nextRule,
         unusedRules = [],
@@ -212,6 +249,7 @@ function filterUnusedRules(pages, stylesheet, ignore, usedSelectors) {
             usedRuleSelectors = filterUnusedSelectors(
                 rule.selectors,
                 ignore,
+                ignoreModifiers,
                 usedSelectors
             );
             unusedRuleSelectors = rule.selectors.filter(function (selector) {
@@ -231,6 +269,7 @@ function filterUnusedRules(pages, stylesheet, ignore, usedSelectors) {
                 pages,
                 { rules: rule.rules },
                 ignore,
+                ignoreModifiers,
                 usedSelectors
             ).stylesheet.rules;
         }
@@ -259,12 +298,12 @@ function filterUnusedRules(pages, stylesheet, ignore, usedSelectors) {
  * @param  {Array}   ignore     List of selectors to be ignored
  * @return {promise}
  */
-module.exports = function uncss(pages, stylesheet, ignore) {
+module.exports = function uncss(pages, stylesheet, ignore, ignoreModifiers) {
     return promise.map(pages, function (page) {
-        return getUsedSelectors(page, stylesheet);
+        return getUsedSelectors(page, stylesheet, ignoreModifiers);
     }).then(function (usedSelectors) {
         usedSelectors = _.flatten(usedSelectors);
-        var processed = filterUnusedRules(pages, stylesheet, ignore, usedSelectors);
+        var processed = filterUnusedRules(pages, stylesheet, ignore, ignoreModifiers, usedSelectors);
 
         return [
             processed,

--- a/src/uncss.js
+++ b/src/uncss.js
@@ -160,7 +160,7 @@ function process(files, options, pages, stylesheets) {
         /* Try and construct a helpful error message */
         throw utility.parseErrorMessage(err, cssStr);
     }
-    return uncss(pages, parsed.stylesheet, options.ignore).spread(function (used, rep) {
+    return uncss(pages, parsed.stylesheet, options.ignore, options.ignoreModifiers).spread(function (used, rep) {
         var usedCss = css.stringify(used);
         if (options.report) {
             report = {

--- a/src/utility.js
+++ b/src/utility.js
@@ -38,6 +38,7 @@ function parseUncssrc(filename) {
      * A string is a RegExp if it starts with '/', since that wouldn't be a valid CSS selector.
      */
     options.ignore = options.ignore ? options.ignore.map(strToRegExp) : undefined;
+    options.ignoreModifiers = options.ignoreModifiers ? options.ignoreModifiers.map(strToRegExp) : undefined;
     options.ignoreSheets = options.ignoreSheets ? options.ignoreSheets.map(strToRegExp) : undefined;
 
     return options;
@@ -173,6 +174,7 @@ function parseErrorMessage(error, cssStr) {
 
 module.exports = {
     isWindows: isWindows,
+    strToRegExp: strToRegExp,
     parseUncssrc: parseUncssrc,
     parseErrorMessage: parseErrorMessage,
     parsePaths: parsePaths,

--- a/tests/output/selectors/uncss.css
+++ b/tests/output/selectors/uncss.css
@@ -130,6 +130,12 @@ h3:hover {
   color: green;
 }
 
+/*** uncss> filename: tests/selectors/fixtures/ignoredmodifier.css ***/
+
+h3.ignored-class {
+  color: green;
+}
+
 /*** uncss> filename: tests/selectors/fixtures/child.css ***/
 
 h1 > span {

--- a/tests/selectors.js
+++ b/tests/selectors.js
@@ -38,7 +38,7 @@ tests = fixtures.map(function (test) {
 describe('Selectors', function () {
 
     before(function (done) {
-        uncss(rfs('selectors/index.html'), { csspath: 'tests/selectors' }, function (err, output) {
+        uncss(rfs('selectors/index.html'), { csspath: 'tests/selectors', ignoreModifiers: ['.ignored-class'] }, function (err, output) {
             if (err) {
                 throw err;
             }

--- a/tests/selectors/expected/ignoredmodifier.css
+++ b/tests/selectors/expected/ignoredmodifier.css
@@ -1,0 +1,3 @@
+h3.ignored-class {
+  color: green;
+}

--- a/tests/selectors/fixtures/ignoredmodifier.css
+++ b/tests/selectors/fixtures/ignoredmodifier.css
@@ -1,0 +1,7 @@
+h3.ignored-class {
+  color: green;
+}
+
+.unused.ignored-class {
+  color: gray;
+}

--- a/tests/selectors/index.html
+++ b/tests/selectors/index.html
@@ -17,6 +17,7 @@
         <link rel="stylesheet" href="fixtures/nthchild.css">
         <link rel="stylesheet" href="fixtures/nthoftype.css">
         <link rel="stylesheet" href="fixtures/pseudo.css">
+        <link rel="stylesheet" href="fixtures/ignoredmodifier.css">
         <link rel="stylesheet" href="fixtures/child.css">
         <link rel="stylesheet" href="fixtures/target.css">
         <link rel="stylesheet" href="fixtures/vendor.css">

--- a/tests/selectors/unused/ignoredmodifier.css
+++ b/tests/selectors/unused/ignoredmodifier.css
@@ -1,0 +1,3 @@
+.unused.ignored-class {
+  color: gray;
+}


### PR DESCRIPTION
The selector is only ignored if it does match without the given modifier.
