### PR TITLE
options.ignoreSheets regexes not picked up on CLI

### DIFF
--- a/bin/uncss
+++ b/bin/uncss
@@ -71,6 +71,17 @@
             });
         }
 
+	if (options.ignoreSheets) {
+            options.ignoreSheets = options.ignoreSheets.map(function (ign) {
+                /* Create RegExes */
+                if (ign[0] === '/') {
+                    /* Remove starting and trailing '/' */
+                    return new RegExp(ign.slice(1, -1));
+                }
+                return ign;
+            });
+        }
+
         /* If used from the command line, concatenate the output */
         uncss(program.args, options, function (err, css) {
             if (err) {


### PR DESCRIPTION
The command line client does'nt pick up regexes like it should for regexes in `options.ignoreSheets`. It currently only converts regexes in `options.ignore`.

This PR fixes that.