### PR TITLE
Support explicitly passing in local files in options.stylsheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Options:
 
 - **csspath** (String): Path where the CSS files are related to the HTML files. By default, UnCSS uses the path specified in the `<link rel="stylesheet" href="path/to/file.css"/>`.
 
-- **stylesheets** (Array): Use these stylesheets instead of those extracted from the HTML files.
+- **stylesheets** (Array): Use these stylesheets instead of those extracted from the HTML files. Prepend paths with `file:` protocol to force use of local stylesheets, otherwise paths will be resolved as a browser would for an anchor tag `href` on the HTML page.
 
 - **ignoreSheets** (Array): Do not process these stylesheets, e.g. Google fonts. Accepts strings or regex patterns.
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -53,6 +53,7 @@ function parseUncssrc(filename) {
 function parsePaths(source, stylesheets, options) {
     return stylesheets.map(function (sheet) {
         var sourceProtocol;
+        var isLocalFile = sheet.substr(0, 5) === 'file:';
 
         if (sheet.substr(0, 4) === 'http') {
             /* No need to parse, it's already a valid path */
@@ -60,7 +61,7 @@ function parsePaths(source, stylesheets, options) {
         }
 
         /* Check if we are fetching over http(s) */
-        if (isURL(source)) {
+        if (isURL(source) && !isLocalFile) {
             sourceProtocol = url.parse(source).protocol;
 
             if (sheet.substr(0, 2) === '//') {
@@ -79,8 +80,8 @@ function parsePaths(source, stylesheets, options) {
         /* Fix the case when there is a query string or hash */
         sheet = sheet.split('?')[0].split('#')[0];
 
-        /* Path already parsed by PhantomJS */
-        if (sheet.substr(0, 5) === 'file:') {
+        /* Path already parsed by PhantomJS, or user passed in local path */
+        if (isLocalFile) {
             sheet = url.parse(sheet).path.replace('%20', ' ');
             /* If on windows, remove first '/' */
             sheet = isWindows() ? sheet.substring(1) : sheet;

--- a/tests/url.js
+++ b/tests/url.js
@@ -75,6 +75,31 @@ describe('Compile the CSS of an HTML page passed by URL', function () {
         );
     });
 
+    it('Deals with local options.stylesheets when using URLs', function (done) {
+        var localStylesheetPath = path.join(__dirname, '/input/main.css');
+
+        this.timeout(25000);
+        uncss(
+            ['http://giakki.github.io/uncss/'],
+            { stylesheets: [path.join('file:', localStylesheetPath)] },
+            function (err, output) {
+                expect(err).to.equal(null);
+
+                fs.readFile(localStylesheetPath, 'utf-8', function (err, stylesheet) {
+                    if (err) {
+                        throw err;
+                    }
+
+                    // First line of output is comment added by uncss, so remove before comparing:
+                    output = output.split('\n').splice(1).join('\n');
+
+                    expect(output).to.equal(stylesheet);
+                    done();
+                });
+            }
+        );
+    });
+
     after(function (done) {
         fs.writeFile(path.join(__dirname, '/output/gh-pages/stylesheets/stylesheet.css'),
                                prevRun,


### PR DESCRIPTION
Without these changes, if you run UnCSS with a remote HTML file, there is no way I could find to override stylesheets with local stylesheets using `options.stylesheets`. Any path in there gets handled as a relative or absolute path based on the remote HTML path.

This PR supports local stylesheets by resolving `options.stylesheets` paths that start with `file:` locally no matter what.
