### PR TITLE
Update dependencies and drop node.js 0.12 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: node_js
 sudo: false
 
 node_js:
-    - "0.12"
     - "4"
-    - "5"
     - "6"
 
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,10 @@
-# http://www.appveyor.com/docs/appveyor-yml
-
 version: "{build}"
 
 clone_depth: 10
 
 environment:
     matrix:
-        - nodejs_version: "0.12"
         - nodejs_version: "4"
-        - nodejs_version: "5"
         - nodejs_version: "6"
 
 install:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "is-absolute-url": "^2.0.0",
     "is-html": "^1.0.0",
     "lodash": "^4.13.1",
-    "object-assign": "^4.1.0",
     "phridge": "^2.0.0",
     "postcss": "^5.0.21",
     "request": "^2.72.0"
@@ -49,13 +48,13 @@
     "chai": "^3.5.0",
     "chai-resemble": "^0.4.1",
     "grunt": "^0.4.5",
-    "grunt-eslint": "^18.0.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-mocha-cov": "^0.4.0",
     "load-grunt-tasks": "^3.5.0",
     "time-grunt": "^1.3.0"
   },
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">=4.0"
   },
   "config": {
     "blanket": {

--- a/package.json
+++ b/package.json
@@ -33,26 +33,26 @@
     "LICENSE.md"
   ],
   "dependencies": {
-    "async": "^1.5.2",
-    "bluebird": "~3.1.5",
-    "commander": "~2.9.0",
-    "glob": "~6.0.1",
-    "is-absolute-url": "~2.0.0",
-    "is-html": "~1.0.0",
-    "lodash": "~4.0.1",
-    "object-assign": "^4.0.1",
-    "phridge": "~2.0.0",
-    "postcss": "~5.0.14",
-    "request": "~2.69.0"
+    "async": "^2.0.1",
+    "bluebird": "^3.4.0",
+    "commander": "^2.9.0",
+    "glob": "^7.0.3",
+    "is-absolute-url": "^2.0.0",
+    "is-html": "^1.0.0",
+    "lodash": "^4.13.1",
+    "object-assign": "^4.1.0",
+    "phridge": "^2.0.0",
+    "postcss": "^5.0.21",
+    "request": "^2.72.0"
   },
   "devDependencies": {
-    "chai": "~3.5.0",
-    "chai-resemble": "~0.4.1",
-    "grunt": "~0.4.5",
+    "chai": "^3.5.0",
+    "chai-resemble": "^0.4.1",
+    "grunt": "^0.4.5",
     "grunt-eslint": "^18.0.0",
-    "grunt-mocha-cov": "~0.4.0",
-    "load-grunt-tasks": "~3.4.0",
-    "time-grunt": "~1.3.0"
+    "grunt-mocha-cov": "^0.4.0",
+    "load-grunt-tasks": "^3.5.0",
+    "time-grunt": "^1.3.0"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/src/uncss.js
+++ b/src/uncss.js
@@ -104,12 +104,12 @@ function getCSS(files, options, pages, stylesheets) {
          */
         stylesheets =
             _.chain(stylesheets)
-            .map(function (sheets, i) {
-                return utility.parsePaths(files[i], sheets, options);
-            })
-            .flatten()
-            .uniq()
-            .value();
+                .map(function (sheets, i) {
+                    return utility.parsePaths(files[i], sheets, options);
+                })
+                .flatten()
+                .uniq()
+                .value();
     } else {
         /* Reset the array if we didn't find any link tags */
         stylesheets = [];

--- a/src/uncss.js
+++ b/src/uncss.js
@@ -2,7 +2,6 @@
 
 var promise = require('bluebird'),
     async = require('async'),
-    assign = require('object-assign'),
     fs = require('fs'),
     glob = require('glob'),
     isHTML = require('is-html'),
@@ -267,7 +266,7 @@ var postcssPlugin = postcss.plugin('uncss', function (opts) {
     });
 
     return function (css, result) { // eslint-disable-line no-unused-vars
-        opts = assign(opts, {
+        opts = Object.assign(opts, {
             // This is used to pass the css object in to processAsPostCSS
             rawPostCss: css
         });


### PR DESCRIPTION
The only issue is that tests fail on Windows. This is from my Windows 7 x64 dev VM since AppVeyor fails with an other error, possibly due to different node.js/npm versions:

```
C:\Users\xmr\Desktop\uncss>node -v && npm -v
v4.4.7
2.15.8

C:\Users\xmr\Desktop\uncss>npm test

> uncss@0.14.1 test C:\Users\xmr\Desktop\uncss
> grunt test

70 passing (2m)
2 failing

1) PhantomJS Should exit only when JS evaluation has finished:
   Error: timeout of 25000ms exceeded. Ensure the done() callback is being called in this test.
    at null.<anonymous> (C:\Users\xmr\Desktop\uncss\node_modules\grunt-mocha-cov\node_modules\mocha\lib\runnable.js:170:19)
    at Timer.listOnTimeout (timers.js:92:15)

2) PhantomJS Should not wait for timeouts by default:
   Error: timeout of 20000ms exceeded. Ensure the done() callback is being called in this test.
    at null.<anonymous> (C:\Users\xmr\Desktop\uncss\node_modules\grunt-mocha-cov\node_modules\mocha\lib\runnable.js:170:19)
    at Timer.listOnTimeout (timers.js:92:15)
```

I wonder if it has to do with phantomjs/phantomjs-prebuilt conflict. We need chai-resemble to use phantomjs-prebuilt to see if that's the problem. See https://github.com/giakki/chai-resemble/issues/3

/CC @mikelambert @giakki 