### PR TITLE
Support comma-seperated animation properties

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -2,6 +2,7 @@
 
 var promise = require('bluebird'),
     phantom = require('./phantom.js'),
+    postcss = require('postcss'),
     _ = require('lodash');
 /* Some styles are applied only with user interaction, and therefore its
  *   selectors cannot be used with querySelectorAll.
@@ -75,10 +76,13 @@ function getUsedAnimations(css) {
     css.walkDecls(function (decl) {
         if (_.endsWith(decl.prop, 'animation-name')) {
             /* Multiple animations, separated by comma */
-            usedAnimations.push.apply(usedAnimations, decl.value.replace(' ', '').split(','));
+            usedAnimations.push.apply(usedAnimations, postcss.list.comma(decl.value));
         } else if (_.endsWith(decl.prop, 'animation')) {
-            /* If declared as animation, it should be in the form 'name Xs etc..' */
-            usedAnimations.push(decl.value.split(' ')[0]);
+            /* Support multiple animations */
+            postcss.list.comma(decl.value).forEach(function (anim) {
+                /* If declared as animation, it should be in the form 'name Xs etc..' */
+                usedAnimations.push(postcss.list.space(anim)[0]);
+            });
         }
     });
     return usedAnimations;


### PR DESCRIPTION
This PR supersedes #244 and fixes #188.

It uses the postcss.list module (http://api.postcss.org/list.html) for safer splitting of values (i.e. `postcss.list.space('1px calc(10% + 1px)') //=> ['1px', 'calc(10% + 1px)']`).

@XhmikosR @mikelambert I'd be willing to write tests for this but I'm unsure how your testing system works.