### PR TITLE
Add more tests for @keyframes

### DIFF
--- a/tests/output/selectors/index.html
+++ b/tests/output/selectors/index.html
@@ -18,10 +18,14 @@
                 </h4>
             </section>
         </div>
+        <!-- NOTE: Placing any other <div> items on this page will break the "not" test! -->
         <h5 class="navy">Navy</h5>
-        <main class="slideRight">
+        <main class="slideRightAndFade">
             Slidin'
         </main>
+        <aside class="flashBounce">
+            Your Attention, Please!
+        </aside>
         <noscript>
             <h6 class="noscript-one">
                 YELLOW

--- a/tests/output/selectors/uncss.css
+++ b/tests/output/selectors/uncss.css
@@ -131,10 +131,58 @@ h1:target {
   }
 }
 
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes flash {
+  from, to {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes bounce {
+  from, to {
+    transform: translate3d(0,0,0);
+  }
+
+  50% {
+    transform: translate3d(0, -10px, 0);
+  }
+}
+
 /* Test both vendor and standard */
 
-.slideRight {
+.slideRightAndFade {
   position: relative;
-  -webkit-animation: slideRight 5s infinite;
-  animation: slideRight 5s infinite;
+  -webkit-animation: slideRight 5s infinite, fadeIn 1s 1;
+  animation: slideRight 5s infinite, fadeIn 1s 1;
+}
+
+/* Test animation-name */
+
+.flashBounce {
+  animation-name: flash, bounce;
+  animation-duration: 1s, 3s;
+  animation-iteration-count: infinite;
 }

--- a/tests/selectors/expected/keyframes.css
+++ b/tests/selectors/expected/keyframes.css
@@ -17,3 +17,43 @@
     left: 200px;
   }
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes flash {
+  from, to {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes bounce {
+  from, to {
+    transform: translate3d(0,0,0);
+  }
+
+  50% {
+    transform: translate3d(0, -10px, 0);
+  }
+}

--- a/tests/selectors/fixtures/keyframes.css
+++ b/tests/selectors/fixtures/keyframes.css
@@ -38,10 +38,58 @@
   }
 }
 
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes flash {
+  from, to {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes bounce {
+  from, to {
+    transform: translate3d(0,0,0);
+  }
+
+  50% {
+    transform: translate3d(0, -10px, 0);
+  }
+}
+
 /* Test both vendor and standard */
 
-.slideRight {
+.slideRightAndFade {
   position: relative;
-  -webkit-animation: slideRight 5s infinite;
-  animation: slideRight 5s infinite;
+  -webkit-animation: slideRight 5s infinite, fadeIn 1s 1;
+  animation: slideRight 5s infinite, fadeIn 1s 1;
+}
+
+/* Test animation-name */
+
+.flashBounce {
+  animation-name: flash, bounce;
+  animation-duration: 1s, 3s;
+  animation-iteration-count: infinite;
 }

--- a/tests/selectors/index.html
+++ b/tests/selectors/index.html
@@ -23,6 +23,15 @@
         <link rel="stylesheet" href="fixtures/keyframes.css">
     </head>
     <body>
+        <!--
+            Some Instructions:
+            - Placing any <div> elements on this page other than
+              div#battleground will break the "not" test!
+            - Any changes made here **must** be reflected in
+              /tests/output/selectors/index.html; otherwise, the
+              "Pages should resemble the reference:Selectors" test
+              will fail!
+        -->
         <div id="battleground" data-section="">
             <h1>
                 <span class="red"> Red </span>
@@ -37,9 +46,12 @@
             </section>
         </div>
         <h5 class="navy">Navy</h5>
-        <main class="slideRight">
+        <main class="slideRightAndFade">
             Slidin'
         </main>
+        <aside class="flashBounce">
+            Your Attention, Please!
+        </aside>
         <noscript>
             <h6 class="noscript-one">
                 YELLOW


### PR DESCRIPTION
As discussed in https://github.com/giakki/uncss/pull/245.

I also added some instructions to `/tests/selectors/index.html`, advising of the things I got bitten with when adding these tests:

> - Placing any `<div>` elements on this page other than
  div#battleground will break the "not" test!
- Any changes made here **must** be reflected in
   /tests/output/selectors/index.html; otherwise, the
   "Pages should resemble the reference:Selectors" test
   will fail!

CC: @mikelambert 