### PR TITLE
Bump tests timeout to fix Windows tests.

### DIFF
--- a/tests/phantomjs.js
+++ b/tests/phantomjs.js
@@ -14,7 +14,7 @@ describe('PhantomJS', function () {
     });
 
     it('Should exit only when JS evaluation has finished', function (done) {
-        this.timeout(25000);
+        this.timeout(100000);
         uncss(['tests/phantomjs/long_wait.html'], function (err, output) {
             expect(err).to.equal(null);
             expect(output).to.include('.long-wait');
@@ -31,7 +31,7 @@ describe('PhantomJS', function () {
     });
 
     it('Should respect options.timeout', function (done) {
-        this.timeout(25000);
+        this.timeout(30000);
         uncss(['tests/phantomjs/timeout.html'], {
             timeout: 5000
         }, function (err, output) {


### PR DESCRIPTION
The numbers are pretty random found with trial and error, but tests seem to pass now on Windows too.