### PR TITLE
Issue 254 get all selectors fix

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -145,7 +145,7 @@ function getUsedSelectors(page, css) {
 function getAllSelectors(css) {
     var selectors = [];
     css.walkRules(function (rule) {
-        selectors.concat(rule.selector);
+        selectors = _.concat(selectors, rule.selector);
     });
     return selectors;
 }

--- a/tests/coverage.js
+++ b/tests/coverage.js
@@ -153,7 +153,9 @@ describe('Options', function () {
             expect(rep).to.have.ownProperty('original');
 
             expect(rep.selectors.all).to.be.instanceof(Array);
+            expect(rep.selectors.all.length).to.not.equal(0);
             expect(rep.selectors.used).to.be.instanceof(Array);
+            expect(rep.selectors.used.length).to.not.equal(0);
 
             done();
         });


### PR DESCRIPTION
@giakki 

I had a bug (#254) with the `report['selectors']['all']` being empty. I fixed it by concatting correctly, I matched how you do it in `getUsedSelectors`

Also added a test for it.