### PR TITLE
Fix incorrect phridge arguments

### DIFF
--- a/src/phantom.js
+++ b/src/phantom.js
@@ -27,8 +27,8 @@ function init(instance) {
     // Convert to bluebird promise
     return new promise(function (resolve) {
         resolve(phridge.spawn({
-            ignoreSslErrors: 'yes',
-            sslProtocol: 'any'
+            '--ignore-ssl-errors': 'yes',
+            '--ssl-protocol': 'any'
         }));
     }).then(function (ph) {
         /* Phridge outputs everything to stdout by default */


### PR DESCRIPTION
Change the arguments passed to phridge.spawn to resemble the actual cli
arguments. If they do not start with a '-', phridge strips them out
before spawning PhantomJS.