### PR TITLE
jsdom: specify `omitJSDOMErrors: true`.

### DIFF
--- a/src/jsdom.js
+++ b/src/jsdom.js
@@ -29,7 +29,7 @@ function fromSource(src, options) {
             FetchExternalResources: ['script'],
             ProcessExternalResources: ['script']
         },
-        virtualConsole: jsdom.createVirtualConsole().sendTo(console)
+        virtualConsole: jsdom.createVirtualConsole().sendTo(console, { omitJSDOMErrors: true })
     };
 
     // The htmlroot option allows root-relative URLs (starting with a slash)


### PR DESCRIPTION
See https://github.com/tmpvar/jsdom#virtual-consoles

This fixes #322 for me. So the behavior is like before the jsdom switch.

/CC @mikelambert @RyanZim 