### PR TITLE
Also ignore form validation (:required, :invalid, :valid) pseudo classes

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -16,6 +16,8 @@ var dePseudify = (function () {
             ':hover', ':active', ':focus',
             /* UI element states */
             ':enabled', ':disabled', ':checked', ':indeterminate',
+            /* form validation */
+            ':required', ':invalid', ':valid',
             /* pseudo elements */
             '::first-line', '::first-letter', '::selection', '::before', '::after',
             /* pseudo classes */


### PR DESCRIPTION
`dePseudify()` strips [several pseudo classes](https://github.com/giakki/uncss/blob/62a6841c423e019595204e1f476cdd0b8a821e9b/src/lib.js#L12) off of selectors such that the processing done by `filterUnusedSelectors()` can determine whether the "parent" selector is actually used or not.

I *believe* that the form validation-related pseudo classes ([`:required`](https://developer.mozilla.org/en-US/docs/Web/CSS/:required), [`:invalid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid), [`:valid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:valid), e.g. as used in Bootstrap 4 Beta) should be given this same treatment.

Without this, [the `document.querySelector()` call in `findAll()` raises an exception](https://github.com/giakki/uncss/blob/62a6841c423e019595204e1f476cdd0b8a821e9b/src/jsdom.js#L101), erroneously causing the selector to be considered as used.

Against master,

```
bin/uncss --raw 'input.used:invalid { border-color: red } input.unused:invalid { border-color: blue }' <<EOF
> <html>
>   <head></head>
>   <body><input class=used></body>
> </html>
> EOF
```

will yield `input.used:invalid { border-color: red } input.unused:invalid { border-color: blue }` whereas with this patch it will drop the unused selector and yield `input.used:invalid { border-color: red }`.

Thank you for the project!