### PR TITLE
Adding user agent string as an available option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ var files   = ['my', 'array', 'of', 'HTML', 'files', 'or', 'http://urls.com'],
         timeout      : 1000,
         htmlroot     : 'public',
         report       : false,
-        uncssrc      : '.uncssrc'
+        uncssrc      : '.uncssrc',
+        userAgent    : 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X)'
     };
 
 uncss(files, options, function (error, output) {
@@ -100,6 +101,7 @@ Options:
   -H, --htmlroot <folder>               Absolute paths' root location
   -u, --uncssrc <file>                  Load these options from <file>
   -n, --noBanner                        Disable banner
+  -a, --userAgent <string>              Use a custom user agent string
 ```
 
 **Note that you can pass both local file paths (which are processed by [glob](https://github.com/isaacs/node-glob)) and URLs to the program.**
@@ -154,6 +156,7 @@ Options:
       ]
   }
   ```
+- **userAgent** (String): The user agent string that jsdom should send when requesting pages. May be useful when loading markup from services which use user agent based device detection to serve custom markup to mobile devices. Defaults to `uncss`.
 
 ### As a PostCSS Plugin
 

--- a/bin/uncss
+++ b/bin/uncss
@@ -29,6 +29,7 @@
         .option('-H, --htmlroot <folder>', 'Absolute paths\' root location')
         .option('-u, --uncssrc <file>', 'Load these options from <file>')
         .option('-n, --noBanner', 'Disable banner')
+        .option('-a, --userAgent <string>', 'Use a custom useragent string')
         .parse(process.argv);
 
     options = {
@@ -41,7 +42,8 @@
         timeout: program.timeout,
         htmlroot: program.htmlroot,
         uncssrc: program.uncssrc,
-        banner: !program.noBanner
+        banner: !program.noBanner,
+        userAgent: program.userAgent
     };
 
     if (program.args.length) {

--- a/src/jsdom.js
+++ b/src/jsdom.js
@@ -16,7 +16,8 @@ function fromSource(src, options) {
             FetchExternalResources: ['script'],
             ProcessExternalResources: ['script']
         },
-        virtualConsole: jsdom.createVirtualConsole().sendTo(console)
+        virtualConsole: jsdom.createVirtualConsole().sendTo(console),
+        userAgent: options.userAgent
     };
 
     // The htmlroot option allows root-relative URLs (starting with a slash)

--- a/src/uncss.js
+++ b/src/uncss.js
@@ -202,7 +202,8 @@ function init(files, options, callback) {
         html: files,
         banner: true,
         // gulp-uncss parameters:
-        raw: null
+        raw: null,
+        userAgent: 'uncss'
     });
 
     process(options).then(([css, report]) => callback(null, css, report), callback);

--- a/tests/jsdom.js
+++ b/tests/jsdom.js
@@ -76,4 +76,31 @@ describe('jsdom', () => {
             done();
         });
     });
+
+    it('Should set the useragent to the value given in options', (done) => {
+        const testUserAgent = 'foo';
+        const options = {
+            htmlroot: path.join(__dirname, './jsdom'),
+            userAgent: testUserAgent
+        };
+        uncss(['tests/jsdom/useragent.html'], options, (err, output) => {
+            expect(err).to.equal(null);
+            expect(output).to.include('useragentset');
+            expect(output).to.not.include('useragentunset');
+            expect(output).to.not.include('error');
+            done();
+        });
+    });
+    it('Should default the useragent to uncss', (done) => {
+        const options = {
+            htmlroot: path.join(__dirname, './jsdom')
+        };
+        uncss(['tests/jsdom/useragent.html'], options, (err, output) => {
+            expect(err).to.equal(null);
+            expect(output).to.include('useragentunset');
+            expect(output).to.not.include('useragentset');
+            expect(output).to.not.include('error');
+            done();
+        });
+    });
 });

--- a/tests/jsdom/jsdom.css
+++ b/tests/jsdom/jsdom.css
@@ -9,3 +9,15 @@
 .timeout {
   margin: 0;
 }
+
+.useragentset {
+  margin: 0;
+}
+
+.useragentunset {
+  margin: 0;
+}
+
+.error {
+  margin: 0;
+}

--- a/tests/jsdom/useragent.html
+++ b/tests/jsdom/useragent.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>jsdom basic test</title>
+        <link rel="stylesheet" href="jsdom.css">
+    </head>
+    <body>
+        <script>
+            /* Add the useragent string */
+            var div = document.createElement('div');
+            var agentMap = {
+                foo: 'useragentset',
+                uncss: 'useragentunset'
+            };
+            div.className = agentMap[navigator.userAgent] || 'error';
+            document.body.appendChild(div);
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
We have adaptive css, ie you get different styles based on whether you're on desktop/tablet/mobile/whatever, so I was hoping you could pull this guy to let me configure the user agent that jsdom uses.