### PR TITLE
Fix regression with dePseudify() if there are multiple pseudos that are to be ignored

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -28,8 +28,8 @@ const dePseudify = (function () {
              */
             '::?-(?:moz|ms|webkit|o)-[a-z0-9-]+'
         ],
-        // Actual regex is of the format: /([^\\])(:hover|:focus)/g
-        pseudosRegex = new RegExp('([^\\\\])(' + ignoredPseudos.join('|') + ')', 'g');
+        // Actual regex is of the format: /([^\\])(:hover|:focus)+/
+        pseudosRegex = new RegExp('([^\\\\])(' + ignoredPseudos.join('|') + ')+');
 
     return function (selector) {
         return selector.replace(pseudosRegex, '$1');

--- a/tests/output/selectors/uncss.css
+++ b/tests/output/selectors/uncss.css
@@ -94,6 +94,11 @@ h3:hover {
   color: green;
 }
  
+/*** uncss> filename: tests/selectors/fixtures/pseudo-class-with-pseudo-element.css ***/
+h5:hover::before {
+  content: "@";
+}
+ 
 /*** uncss> filename: tests/selectors/fixtures/child.css ***/
 h1 > span {
   color: crimson;

--- a/tests/selectors/expected/pseudo-class-with-pseudo-element.css
+++ b/tests/selectors/expected/pseudo-class-with-pseudo-element.css
@@ -1,0 +1,3 @@
+h5:hover::before {
+  content: "@";
+}

--- a/tests/selectors/fixtures/pseudo-class-with-pseudo-element.css
+++ b/tests/selectors/fixtures/pseudo-class-with-pseudo-element.css
@@ -1,0 +1,7 @@
+h5:hover::before {
+  content: "@";
+}
+
+.unused:hover::before {
+  content: "!";
+}

--- a/tests/selectors/index.html
+++ b/tests/selectors/index.html
@@ -17,6 +17,7 @@
         <link rel="stylesheet" href="fixtures/nthchild.css">
         <link rel="stylesheet" href="fixtures/nthoftype.css">
         <link rel="stylesheet" href="fixtures/pseudo.css">
+        <link rel="stylesheet" href="fixtures/pseudo-class-with-pseudo-element.css">
         <link rel="stylesheet" href="fixtures/child.css">
         <link rel="stylesheet" href="fixtures/target.css">
         <link rel="stylesheet" href="fixtures/vendor.css">

--- a/tests/selectors/unused/pseudo-class-with-pseudo-element.css
+++ b/tests/selectors/unused/pseudo-class-with-pseudo-element.css
@@ -1,0 +1,3 @@
+.unused:hover::before {
+  content: "!";
+}


### PR DESCRIPTION
Between 0.15.0 and 0.16.0, `dePseudify()` seemed to start mishandling selectors that have multiple pseudos, which isn't a case well-represented in the test suite but does occur in the wild (e.g. in Bootstrap 4).

I'm including here a failing test and a possible fix.

---

On 0.15.0:

```
$ echo '<p class="used">Hi</p>' | ./bin/uncss --raw '.used { color: red } .unused:visited::before { content: "a" }'
.used { color: red }
```

On master / 0.16.0:

```
$ echo '<p class="used">Hi</p>' | ./bin/uncss --raw '.used { color: red } .unused:visited::before { content: "a" }'
.used { color: red } .unused:visited::before { content: "a" }
```

I bisected this to 0170fe1a843c7c6d90c89647ece20c80558b141f (#345), which I think is the culprit.

That `pseudosRegex = new RegExp('([^\\\\])(' + ignoredPseudos.join('|') + ')', 'g')` produces weird results if you have multiple pseudos hanging off a selector, e.g.:

```
$ node
> ignoredPseudos = [ . . . ]
[ . . . ]
> pseudosRegex = new RegExp('([^\\\\])(' + ignoredPseudos.join('|') + ')', 'g')
/([^\\])(:link|:visited|:hover|:active|:focus|:enabled|:disabled|:checked|:indeterminate|:required|:invalid|:valid|::first-line|::first-letter|::selection|::before|::after|:target|:before|:after|::?-(?:moz|ms|webkit|o)-[a-z0-9-]+)/g
> 'a:visited'.replace(pseudosRegex, '$1')
'a'
> 'a::before'.replace(pseudosRegex, '$1')
'a'
> 'a:visited:hover'.replace(pseudosRegex, '$1')
'a:hover'
> 'a:visited::before'.replace(pseudosRegex, '$1')
'a:'
```

I *think* if we just give the pseudo group a quantifier instead of trying to use the `g` flag from the old regex, we would get what we want (i.e. replace on any non-slash character followed by one *or more* pseudos):

```
> pseudosRegex = new RegExp('([^\\\\])(' + ignoredPseudos.join('|') + ')+')
/([^\\])(:link|:visited|:hover|:active|:focus|:enabled|:disabled|:checked|:indeterminate|:required|:invalid|:valid|::first-line|::first-letter|::selection|::before|::after|:target|:before|:after|::?-(?:moz|ms|webkit|o)-[a-z0-9-]+)+/
> 'a:visited'.replace(pseudosRegex, '$1')
'a'
> 'a::before'.replace(pseudosRegex, '$1')
'a'
> 'a:visited:hover'.replace(pseudosRegex, '$1')
'a'
> 'a:visited::before'.replace(pseudosRegex, '$1')
'a'
```

It should also still work for the original "escaped" case the original change wanted to accomplished:

```
> '.sm\\:hover\\:font-hairline:hover'.replace(pseudosRegex, '$1')
'.sm\\:hover\\:font-hairline'
> '.sm\\:hover\\:font-hairline:hover::before'.replace(pseudosRegex, '$1')
'.sm\\:hover\\:font-hairline'
```

It also seems to work for at least what is present in today's test suite.