### PR TITLE
Include banner in options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ var files   = ['my', 'array', 'of', 'HTML', 'files', 'or', 'http://urls.com'],
         timeout      : 1000,
         htmlroot     : 'public',
         report       : false,
+        banner       : false,
         uncssrc      : '.uncssrc',
         userAgent    : 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X)'
     };


### PR DESCRIPTION
I noticed there wasn't a banner config option in the js example. I had to do a bit of fiddling with `noBanner: true` before I got the actual option right. Figured it would be easier to just include it in the readme 😄 